### PR TITLE
Make integer seeds have a visible effect

### DIFF
--- a/lib/simple-random/simple_random.rb
+++ b/lib/simple-random/simple_random.rb
@@ -9,7 +9,7 @@ class SimpleRandom
       @m_w = args.first.to_i if args.first.to_i != 0
       @m_z = args.last.to_i if args.last.to_i != 0
     elsif args.first.is_a?(Numeric)
-      @m_w = args.first.to_i if args.first.to_i != 0
+      @m_z = args.first.to_i if args.first.to_i != 0
     elsif args.first.is_a?(Time)
       x = (args.first.to_f * 1000000).to_i
       @m_w = x >> 16

--- a/test/test_simple_random.rb
+++ b/test/test_simple_random.rb
@@ -232,5 +232,17 @@ class TestSimpleRandom < MiniTest::Test
       assert samples.size == thread_count
       assert samples.uniq.size == 1
     end
+
+    should "provide different results with different integer seeds" do
+      r1 = SimpleRandom.new
+      r1.set_seed(2)
+      r2 = SimpleRandom.new
+      r2.set_seed(1234512343214134)
+
+      r1_randoms = 100.times.map { r1.uniform(0, 10).floor }
+      r2_randoms = 100.times.map { r2.uniform(0, 10).floor }
+
+      assert r1_randoms != r2_randoms
+    end
   end
 end


### PR DESCRIPTION
I noted strange behaviour when trying to implement a Fisher-Yates shuffle on top of `SimpleRandom#uniform`, in that I would get the same shuffle order even if I passed wildly different integer values to `set_seed`.

The effect of a single `Numeric` seed upon the stream of random numbers from `SimpleRandom` was extremely minor, as shown by the previously-failing test case included in this commit.

The solution seems to be to apply the seed argument to m_z rather than m_w.